### PR TITLE
Less frequent sampling for custom authroizer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 0.01,
+  tracesSampleRate: 0.0001,
 });
 
 let data;


### PR DESCRIPTION
We are still getting ~7k events a day in Sentry. This change should bring it down to ~70.