### PR TITLE
No sampling on performance on the authorizer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 0.0001,
+  tracesSampleRate: 0,
 });
 
 let data;


### PR DESCRIPTION
Sentry keeps getting 100k events a week from the authorizor taking all our performance token allocation. It's working and doesn't need sampling right now. 