### PR TITLE
Fix newlines in env var

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -21,7 +21,7 @@ const getPolicyDocument = (effect, resource) => {
 // extract and return the Bearer Token from the Lambda event parameters
 const getToken = (params) => {
   if (!params.type || params.type !== "TOKEN") {
-    throw new Error('Expected "event.type" parameter to have value "TOKEN"..');
+    throw new Error('Expected "event.type" parameter to have value "TOKEN"');
   }
 
   const tokenString = params.authorizationToken;
@@ -44,13 +44,12 @@ const jwtOptions = {
 };
 
 module.exports.authenticate = (params) => {
-  console.log("Authenticate. v: 1.0.0");
   console.log(params);
   const token = getToken(params);
 
   const decoded = jwt.decode(token, { complete: true });
   if (!decoded || !decoded.header) {
-    throw new Error("invalid token!");
+    throw new Error("invalid token");
   }
 
   let signingKeyPromise;

--- a/lib.js
+++ b/lib.js
@@ -21,7 +21,7 @@ const getPolicyDocument = (effect, resource) => {
 // extract and return the Bearer Token from the Lambda event parameters
 const getToken = (params) => {
   if (!params.type || params.type !== "TOKEN") {
-    throw new Error('Expected "event.type" parameter to have value "TOKEN"');
+    throw new Error('Expected "event.type" parameter to have value "TOKEN"..');
   }
 
   const tokenString = params.authorizationToken;

--- a/lib.js
+++ b/lib.js
@@ -62,7 +62,9 @@ module.exports.authenticate = (params) => {
     );
   } else {
     // Otherwise, this is a JWT we've issued ourselves, so we can use the public key we have
-    signingKeyPromise = Promise.resolve(process.env.PUBLIC_KEY);
+    signingKeyPromise = Promise.resolve(
+      process.env.PUBLIC_KEY.replace(/\\n/g, "\n")
+    );
   }
 
   return signingKeyPromise

--- a/lib.js
+++ b/lib.js
@@ -44,6 +44,7 @@ const jwtOptions = {
 };
 
 module.exports.authenticate = (params) => {
+  console.log("Authenticate. v: 1.0.0");
   console.log(params);
   const token = getToken(params);
 

--- a/lib.js
+++ b/lib.js
@@ -48,8 +48,8 @@ module.exports.authenticate = (params) => {
   const token = getToken(params);
 
   const decoded = jwt.decode(token, { complete: true });
-  if (!decoded || !decoded.header || !decoded.header.kid) {
-    throw new Error("invalid token");
+  if (!decoded || !decoded.header) {
+    throw new Error("invalid token!");
   }
 
   let signingKeyPromise;


### PR DESCRIPTION
This makes sure newlines in the PUBLIC_KEY env var will be handled. It also fixes a bug where JWT's without a `kid` field were denied, even though those are now legal.